### PR TITLE
Changed the first heading

### DIFF
--- a/.github/ISSUE_TEMPLATE/pd-assignment.yml
+++ b/.github/ISSUE_TEMPLATE/pd-assignment.yml
@@ -9,7 +9,7 @@ body:
         Thanks for taking the time to assign this coursework!
   - type: input
     attributes:
-      label: Link to the coursework
+      label: Coursework content
     validations:
       required: true
   - type: input


### PR DESCRIPTION
PD coursework doesn't use Github repos, therefore we don't use URLs to the coursework. Instead, we will describe the content of the coursework on the form itself.