### PR TITLE
delete config.yml contents

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,1 @@
-blank_issues_enabled: true
-contact_links:
-  - name: CYF
-    url: contact@codeyourfuture.io
-    about: Please report serious issues here.
-  - name: Join CYF
-    url: https://codeyourfuture.io/volunteers/
-    about: Join CYF here
-  - name: CYF Slack
-    url: codeyourfuture.slack.com
-    about: Come to #cyf-curriculum and chat
-  - name: CYF Tech Ed
-    url: https://github.com/orgs/CodeYourFuture/teams/mentors
-    about: CYF mentors on Github
+


### PR DESCRIPTION
Testing org-wide issue templates. The docs aren't clear if they can be disabled just be having a `config.yml` file or if there needs to be something in it.
